### PR TITLE
Use music-metadata-browser to retrieve metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "twotone",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {


### PR DESCRIPTION
Would you like to try [music-metadata-browser](https://github.com/Borewit/music-metadata-browser). 

As this PR demonstrated it will simplify your retrieval of metadata a lot.

- This parser will handle Ogg, FLAC, MP3 or any common audio format (will no longer need multiple parsers) 
- Support for promises out of the box
- mime-type directly available in the picture object
- Very detailed access to format information and metadata tags, easy to use API

This is just a proof of concept, I have not tested it run-time.

Let me know if you need any help.